### PR TITLE
modified mutablePow10 to return a fixed AlyaNum

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -518,7 +518,7 @@ end
 function mutablePow10(number: AlyaNum): AlyaNum
 	if number.sign == 1 then
 		number.exponent += 1
-		return number
+		return fix(number)
 	else
 		return AlyaNum.new(math.pow(10, toNumber(number)))
 	end


### PR DESCRIPTION
originally it returned just incremented the exponent, therefore breaking comparisons between fixed and non fixed AlyaNums

AlyaNum.pow(AlyaNum.new(2), 2) would return as greater than AlyaNum.new(500)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of positive-number results during power-of-ten calculations.
  * Ensures exponent-related operations return consistently adjusted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->